### PR TITLE
Change tab heading

### DIFF
--- a/src/client/templates/pull.html
+++ b/src/client/templates/pull.html
@@ -197,7 +197,7 @@
 
           <tab>
             <tab-heading>
-              <span class="octicon octicon-check"></span> Status
+              <span class="octicon octicon-check"></span> Services
             </tab-heading>
             <table class="table table-plain">
               <tr>


### PR DESCRIPTION
Change tab heading from 'status' to 'services' to better link from merge are to status tab.