### PR TITLE
added change to get papertrail location

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -78,7 +78,8 @@ module.exports = {
 
         papertrail: {
             host: process.env.PAPERTRAIL_HOST,
-            port: process.env.PAPERTRAIL_PORT
+            port: process.env.PAPERTRAIL_PORT,
+            location: process.env.PAPERTRAIL_LOCATION
         },
 
         static: {

--- a/src/server/services/papertrail.js
+++ b/src/server/services/papertrail.js
@@ -8,7 +8,7 @@ module.exports = (function(){
           port: config.server.papertrail.port || '',
           colorize: true,
           logFormat: function(level, message) {
-              return '[' + level +  '] ' + message;
+              return '[' + config.server.papertrail.location + ']' + '[' + level +  '] ' + message;
           }
       })
     ] : [];


### PR DESCRIPTION
Right now, it's not immediately clear on Papertrail what systems events are getting triggered on. ![screen shot 2015-02-06 at 11 18 33 am](https://cloud.githubusercontent.com/assets/2757082/6085853/1d3fc7c8-adf2-11e4-831d-ba7995bad7b6.png)

This fix would allow us to set the environment variable to more clearly show what system events get triggered from. Example from my machine: gabe-localhost.

![screen shot 2015-02-06 at 11 36 24 am](https://cloud.githubusercontent.com/assets/2757082/6086167/81588e00-adf4-11e4-9c87-6dd2560925d4.png)

We can have separate ones for staging, production, dev, etc.
