### PR TITLE
Feature/migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "keen-js": "^3.2.1",
     "merge": "^1.1.3",
     "minimatch": "^2.0.1",
+    "mongodb-migrations": "^0.2.1",
     "mongoose": "^3.8.11",
     "node-sass": "^0.9.3",
     "nodemailer": "^1.2.1",

--- a/src/client/controller/pull.js
+++ b/src/client/controller/pull.js
@@ -20,7 +20,7 @@ module.controller('PullCtrl', ['$scope', '$rootScope', '$state', '$stateParams',
         $scope.head = pull.value.head.sha;
 
         // get the pull request
-        $scope.pull = Pull.milestone(pull.value) && Pull.render(pull.value) && Pull.stars(pull.value, true);
+        $scope.pull = Pull.render(pull.value) && Pull.stars(pull.value, true);
 
         // set the line selection
         $scope.reference = {selection: {}, issues: null};
@@ -78,11 +78,11 @@ module.controller('PullCtrl', ['$scope', '$rootScope', '$state', '$stateParams',
         });
 
         // get the open issues
-        $scope.open = $HUB.call('issues', 'repoIssues', {
+        $scope.open = $scope.pull.milestone ? $HUB.wrap('issues', 'repoIssues', {
             user: $stateParams.user,
             repo: $stateParams.repo,
             state: 'open',
-            milestone: $scope.pull.milestone ? $scope.pull.milestone.number : null
+            milestone: $scope.pull.milestone.number
         }, function(err, issues) {
             issues.value = issues.value || [];
             if(!err) {
@@ -90,10 +90,10 @@ module.controller('PullCtrl', ['$scope', '$rootScope', '$state', '$stateParams',
                     issue = Issue.parse(issue);
                 });
             }
-        });
+        }) : {value: []};
 
         // get the closed issues
-        $scope.closed = $HUB.call('issues', 'repoIssues', {
+        $scope.closed = $scope.pull.milestone ? $HUB.wrap('issues', 'repoIssues', {
             user: $stateParams.user,
             repo: $stateParams.repo,
             state: 'closed',
@@ -105,7 +105,7 @@ module.controller('PullCtrl', ['$scope', '$rootScope', '$state', '$stateParams',
                     issue = Issue.parse(issue);
                 });
             }
-        });
+        }) : {value: []};
 
         //
         // UI text

--- a/src/client/controller/pull.js
+++ b/src/client/controller/pull.js
@@ -78,7 +78,7 @@ module.controller('PullCtrl', ['$scope', '$rootScope', '$state', '$stateParams',
         });
 
         // get the open issues
-        $scope.open = $scope.pull.milestone ? $HUB.wrap('issues', 'repoIssues', {
+        $scope.open = $scope.pull.milestone ? $HUB.call('issues', 'repoIssues', {
             user: $stateParams.user,
             repo: $stateParams.repo,
             state: 'open',
@@ -93,7 +93,7 @@ module.controller('PullCtrl', ['$scope', '$rootScope', '$state', '$stateParams',
         }) : {value: []};
 
         // get the closed issues
-        $scope.closed = $scope.pull.milestone ? $HUB.wrap('issues', 'repoIssues', {
+        $scope.closed = $scope.pull.milestone ? $HUB.call('issues', 'repoIssues', {
             user: $stateParams.user,
             repo: $stateParams.repo,
             state: 'closed',

--- a/src/client/services/Pull.js
+++ b/src/client/services/Pull.js
@@ -13,7 +13,7 @@ module.factory('Pull', ['$HUB', '$RPC', '$stateParams', function($HUB, $RPC, $st
                     repo: pull.base.repo.name,
                     number: pull.milestone.number
                 }, function(err, milestone) {
-                    if(!err) {
+                    if(!err && milestone.id === milestone.value.id) {
                         pull.milestone = milestone.value;
                     }
                 });

--- a/src/client/services/Pull.js
+++ b/src/client/services/Pull.js
@@ -13,7 +13,7 @@ module.factory('Pull', ['$HUB', '$RPC', '$stateParams', function($HUB, $RPC, $st
                     repo: pull.base.repo.name,
                     number: pull.milestone.number
                 }, function(err, milestone) {
-                    if(!err && milestone.id === milestone.value.id) {
+                    if(!err && pull.milestone.id === milestone.value.id) {
                         pull.milestone = milestone.value;
                     }
                 });

--- a/src/client/templates/issue/list.html
+++ b/src/client/templates/issue/list.html
@@ -4,7 +4,8 @@
 
   <tr class="select" 
       ng-repeat="issue in (state==='open' ? open : closed).value | filter:{state: state} | in:reference.issues:'number'"
-      ui-sref="repo.pull.issue.detail({ issue: issue.number })">
+      ui-sref="repo.pull.issue.detail({ issue: issue.number })"
+      ng-show="issue.milestone.id===pull.milestone.id">
 
     <td style="width:40px; padding-right:0;">
       <img ng-src="{{ issue.user.avatar_url }}&s=40" width="40px" />

--- a/src/config.js
+++ b/src/config.js
@@ -66,8 +66,15 @@ module.exports = {
         },
 
         mongodb: {
-            uri: process.env.MONGODB || process.env.MONGOLAB_URI
+            host: process.env.MONGO_HOST,
+            port: process.env.MONGO_PORT || 27017,
+            db: process.env.MONGO_DB,
+            user: process.env.MONGO_USER,
+            password: process.env.MONGO_PASS,
+            collection: 'migrations'
         },
+
+        mongodb_uri: 'mongodb://' + (process.env.MONGO_USER ? process.env.MONGO_USER + ':' + process.env.MONGO_PASS + '@' : '') +  process.env.MONGO_HOST + ':' + (process.env.MONGO_PORT || 27017) + '/' + process.env.MONGO_DB,
 
         keen: {
             pid: process.env.KEENIO_PID,
@@ -93,6 +100,10 @@ module.exports = {
 
         webhooks: [
             __dirname + '/server/webhooks/*.js'
+        ],
+
+        migrations: [
+            __dirname + '/server/migrations/*.js'
         ],
 
         documents: [

--- a/src/server/api/issue.js
+++ b/src/server/api/issue.js
@@ -67,7 +67,7 @@ module.exports = {
         body += '|' + req.args.sha + '|' + fileReference + '| #' + req.args.number + ' |' + ninjaReference + '|';
 
         milestone.get(req.args.user, req.args.repo, req.args.repo_uuid, req.args.number, req.user.token,
-            function(err, milestone) {
+            function(err, mile) {
                 if(err) {
                     return done(err);
                 }
@@ -81,7 +81,7 @@ module.exports = {
                         body: body,
                         title: req.args.title,
                         labels: ['review.ninja'],
-                        milestone: milestone.number
+                        milestone: mile.number
                     },
                     token: req.user.token
                 }, done);

--- a/src/server/controller/badge.js
+++ b/src/server/controller/badge.js
@@ -29,7 +29,10 @@ router.all('/:repoId/pull/:number/badge', function(req, res) {
         }
     }
 
-    Milestone.findOne({repo: req.params.repoId, pull: req.params.number}, function(err, milestone) {
+    Milestone.findOne({
+        pull: req.params.number,
+        repo: req.params.repoId
+    }, function(err, mile) {
 
         var options = {
             obj: 'repos',
@@ -51,14 +54,14 @@ router.all('/:repoId/pull/:number/badge', function(req, res) {
                 arg: {
                     user: githubRepo.owner.login,
                     repo: githubRepo.name,
-                    number: milestone ?  milestone.number : null
+                    number: mile ?  mile.number : null
                 }
             };
             addAuth(options);
 
-            github.call(options, function(err, mile) {
+            github.call(options, function(err, githubMile) {
 
-                var issues = mile ? mile.open_issues : 0;
+                var issues = githubMile && mile.id === githubMile.id ? githubMile.open_issues : 0;
 
                 var options = {
                     obj: 'pullRequests',

--- a/src/server/documents/milestone.js
+++ b/src/server/documents/milestone.js
@@ -8,8 +8,8 @@ var MilestoneSchema = mongoose.Schema({
 });
 
 MilestoneSchema.index({
-    id: 1,
-    number: 1
+    pull: 1,
+    repo: 1
 }, {
     unique: true
 });

--- a/src/server/documents/milestone.js
+++ b/src/server/documents/milestone.js
@@ -1,13 +1,14 @@
 var mongoose = require('mongoose');
 
 var MilestoneSchema = mongoose.Schema({
+    id: Number,
     pull: Number,
     repo: Number,
     number: Number
 });
 
 MilestoneSchema.index({
-    repo: 1,
+    id: 1,
     number: 1
 }, {
     unique: true

--- a/src/server/migrations/1.1.0.js
+++ b/src/server/migrations/1.1.0.js
@@ -1,0 +1,95 @@
+exports.id = '1.1.0';
+
+// modules
+var async = require('async');
+
+// services
+var github = require('../services/github');
+
+exports.up = function (done) {
+
+    var Users = this.db.collection('users');
+    var Milestones = this.db.collection('milestones');
+
+    var tokens = {};
+
+    Users.find({}).toArray(function(err, users) {
+        if(err) {
+            return done(err);
+        }
+
+        users.forEach(function(user) {
+            if(user.repos) {
+                user.repos.forEach(function(repo) {
+                    if(!tokens[repo]) {
+                        tokens[repo] = [];
+                    }
+                    tokens[repo].push(user.token);
+                });
+            }
+        });
+
+        Milestones.find({}).toArray(function(err, miles) {
+            if(err) {
+                return done(err);
+            }
+
+            async.each(miles, function(oldMile, callback) {
+
+                var newMile;
+                var _tokens = tokens[oldMile.repo] || [];
+
+                async.eachSeries(_tokens, function(token, callback) {
+
+                    if(newMile) {
+                        return callback();
+                    }
+
+                    github.call({
+                        obj: 'repos',
+                        fun: 'one',
+                        arg: {id: oldMile.repo},
+                        token: token
+                    }, function(err, repo) {
+
+                        if(err) {
+                            return callback();
+                        }
+
+                        github.call({
+                            obj: 'issues',
+                            fun: 'getMilestone',
+                            arg: {
+                                user: repo.owner.login,
+                                repo: repo.name,
+                                number: oldMile.number
+                            },
+                            token: token
+                        }, function(err, githubMile) {
+
+                            if(!err) {
+                                newMile = {
+                                    id: githubMile.id,
+                                    pull: oldMile.pull,
+                                    repo: oldMile.repo,
+                                    number: oldMile.number
+                                };
+                            }
+
+                            callback();
+                        });
+                    });
+
+                }, function(err) {
+
+                    if(newMile) {
+                        Milestones.update(oldMile, {$set: newMile}, callback);
+                    } else {
+                        Milestones.remove(oldMile, callback);
+                    }
+                });
+
+            }, done);
+        });
+    });
+};

--- a/src/server/migrations/1.1.0_1.js
+++ b/src/server/migrations/1.1.0_1.js
@@ -1,0 +1,10 @@
+exports.id = '1.1.0_1';
+
+exports.up = function (done) {
+
+    var Milestones = this.db.collection('milestones');
+
+    Milestones.dropIndex({repo: 1, number: 1}, function() {
+        Milestones.ensureIndex({id: 1, number: 1}, {unique: true}, done);
+    });
+};

--- a/src/server/migrations/1.1.0_1.js
+++ b/src/server/migrations/1.1.0_1.js
@@ -4,7 +4,7 @@ exports.up = function (done) {
 
     var Milestones = this.db.collection('milestones');
 
-    Milestones.dropIndex({repo: 1, number: 1}, function() {
-        Milestones.ensureIndex({id: 1, number: 1}, {unique: true}, done);
-    });
+    Milestones.dropIndex({repo: 1, number: 1});
+
+    Milestones.ensureIndex({pull: 1, repo: 1}, {unique: true}, done);
 };

--- a/src/server/services/milestone.js
+++ b/src/server/services/milestone.js
@@ -10,7 +10,7 @@ module.exports = {
         Milestone.findOne({
             pull: number,
             repo: repo_uuid
-        }, function(err, milestone) {
+        }, function(err, mile) {
 
             if(err) {
                 return done(err);
@@ -23,12 +23,12 @@ module.exports = {
                 arg: {
                     user: user,
                     repo: repo,
-                    number: milestone ? milestone.number : null
+                    number: mile ? mile.number : null
                 },
                 token: token
-            }, function(err) {
-                if(!err) {
-                    return done(err, milestone);
+            }, function(err, githubMile) {
+                if(!err && mile.id === githubMile.id) {
+                    return done(err, githubMile);
                 }
 
                 // create milestone if non-existant
@@ -41,18 +41,16 @@ module.exports = {
                         title: config.milestone_prefix + 'ReviewNinja PR #' + number
                     },
                     token: token
-                }, function(err, milestone) {
+                }, function(err, mile) {
                     if(err) {
                         return done(err);
                     }
 
-                    Milestone.findOneAndUpdate({
+                    Milestone.create({
+                        id: mile.id,
                         pull: number,
-                        repo: repo_uuid
-                    }, {
-                        number: milestone.number
-                    }, {
-                        upsert: true
+                        repo: repo_uuid,
+                        number: mile.number
                     }, done);
                 });
             });
@@ -63,27 +61,27 @@ module.exports = {
         Milestone.findOne({
             pull: number,
             repo: repo_uuid
-        }, function(err, milestone) {
-            if(!err && milestone) {
+        }, function(err, mile) {
+            if(!err && mile) {
                 github.call({
                     obj: 'issues',
                     fun: 'getMilestone',
                     arg: {
                         user: user,
                         repo: repo,
-                        number: milestone.number
+                        number: mile.number
                     },
                     token: token
-                }, function(err, milestone) {
-                    if(!err) {
+                }, function(err, githubMile) {
+                    if(!err && mile.id === githubMile.id) {
                         github.call({
                             obj: 'issues',
                             fun: 'updateMilestone',
                             arg: {
                                 user: user,
                                 repo: repo,
-                                number: milestone.number,
-                                title: milestone.title,
+                                number: githubMile.number,
+                                title: githubMile.title,
                                 state: 'closed'
                             },
                             token: token

--- a/src/server/services/milestone.js
+++ b/src/server/services/milestone.js
@@ -28,7 +28,7 @@ module.exports = {
                 token: token
             }, function(err, githubMile) {
                 if(!err && mile.id === githubMile.id) {
-                    return done(err, githubMile);
+                    return done(err, mile);
                 }
 
                 // create milestone if non-existant
@@ -46,12 +46,13 @@ module.exports = {
                         return done(err);
                     }
 
-                    Milestone.create({
-                        id: mile.id,
+                    Milestone.findOneAndUpdate({
                         pull: number,
-                        repo: repo_uuid,
+                        repo: repo_uuid
+                    }, {
+                        id: mile.id,
                         number: mile.number
-                    }, done);
+                    }, {upsert: true}, done);
                 });
             });
         });

--- a/src/server/services/socket.js
+++ b/src/server/services/socket.js
@@ -12,8 +12,8 @@ module.exports = {
             issues: function(done) {
                 data.number = args.issue.number;
                 Milestone.findOne({
-                    repo: args.repository.id,
-                    number: args.issue.milestone ? args.issue.milestone.number : null
+                    id: args.issue.milestone ? args.issue.milestone.id : null,
+                    repo: args.repository.id
                 }, function(err, mile) {
                     if(!err && mile) {
                         data.pull = mile.pull;

--- a/src/server/services/status.js
+++ b/src/server/services/status.js
@@ -22,7 +22,7 @@ module.exports = {
                 Milestone.findOne({
                     pull: args.number,
                     repo: args.repo_uuid
-                }, function(err, milestone) {
+                }, function(err, mile) {
 
                     github.call({
                         obj: 'issues',
@@ -30,12 +30,12 @@ module.exports = {
                         arg: {
                             user: args.user,
                             repo: args.repo,
-                            number: milestone ? milestone.number : null
+                            number: mile ? mile.number : null
                         },
                         token: args.token
-                    }, function(err, milestone) {
+                    }, function(err, githubMile) {
 
-                        var issues = milestone ? milestone.open_issues : 0;
+                        var issues = githubMile && mile.id === githubMile.id ? githubMile.open_issues : 0;
                         var reachedThreshold =  stars.length >= repo.threshold;
 
                         var status = issues ? 'failure' : reachedThreshold ? 'success' : 'pending';

--- a/src/server/webhooks/issues.js
+++ b/src/server/webhooks/issues.js
@@ -54,7 +54,7 @@ module.exports = function(req, res) {
     var repo = req.args.repository.name;
     var issue = req.args.issue.id;
     var sender = req.args.sender;
-    var number = req.args.issue.milestone.number;
+    var mile_uuid = req.args.issue.milestone.id;
     var repo_uuid = req.args.repository.id;
 
     User.findOne({ _id: req.params.id }, function(err, ninja) {
@@ -68,8 +68,8 @@ module.exports = function(req, res) {
         }
 
         Milestone.findOne({
-            repo: repo_uuid,
-            number: number
+            id: mile_uuid,
+            repo: repo_uuid
         }, function(err, mile) {
 
             if(err || !mile) {
@@ -117,8 +117,8 @@ module.exports = function(req, res) {
                 closed: function() {
 
                     // send a notification if all issues are closed
-                    getMilestone(user, repo, number, ninja.token, function(err, milestone) {
-                        if(!err && !milestone.open_issues) {
+                    getMilestone(user, repo, mile.number, ninja.token, function(err, githubMile) {
+                        if(!err && !githubMile.open_issues) {
                             notification.sendmail('closed_issue', user, repo, repo_uuid, ninja.token, mile.pull, {
                                 user: user,
                                 repo: repo,

--- a/src/server/webhooks/pull_request.js
+++ b/src/server/webhooks/pull_request.js
@@ -78,32 +78,6 @@ module.exports = function(req, res) {
                 if(req.args.pull_request.merged) {
                     var event = user + ':' + repo + ':' + 'pull-request-' + number + ':merged';
                     io.emit(event, number);
-
-                    Milestone.findOne({
-                        pull: number,
-                        repo: repo_uuid
-                    }, function(err, mile) {
-                        github.call({
-                            obj: 'issues',
-                            fun: 'getMilestone',
-                            arg: {
-                                user: user,
-                                repo: repo,
-                                number: mile ? mile.number : null
-                            },
-                            token: ninja.token
-                        }, function(err, mile) {
-                            // log to keenio
-                            keenio.addEvent('pull_request:merged', {
-                                user: sender.id,
-                                repo: repo_uuid,
-                                name: sender.login,
-                                pull: number,
-                                mile: milestone.number,
-                                open_issues: mile ? mile.open_issues : 0
-                            });
-                        });
-                    });
                 }
 
                 milestone.close(user, repo, repo_uuid, number, ninja.token);

--- a/src/server/wrap/pullRequests.js
+++ b/src/server/wrap/pullRequests.js
@@ -22,30 +22,14 @@ module.exports = {
                 pull.watched = !settings ? true : pullRequest.isWatched(pull, settings);
             }
 
-            Milestone.findOne({pull: pull.number, repo: pull.base.repo.id}, function(err, mile) {
-                if(err || !mile) {
-                    return done(null, pull);
+            Milestone.findOne({
+                pull: pull.number,
+                repo: pull.base.repo.id
+            }, function(err, mile) {
+                if(!err) {
+                    pull.milestone = mile;
                 }
-
-                github.call({
-                    obj: 'issues',
-                    fun: 'getMilestone',
-                    arg: {
-                        user: req.args.arg.user,
-                        repo: req.args.arg.repo,
-                        number: mile.number
-                    }
-                }, function(err, githubMile) {
-                    if(!err) {
-                        pull.milestone = mile.id === githubMile.id ? githubMile : null;
-
-                        if(mile.id !== githubMile.id) {
-                            mile.remove();
-                        }
-                    }
-
-                    done(null, pull);
-                });
+                done(null, pull);
             });
         });
     },
@@ -89,9 +73,12 @@ module.exports = {
 
             // set the stars and milestone
             async.each(pulls, function(pull, callback) {
-                Milestone.findOne({pull: pull.number, repo: pull.base.repo.id}, function(err, milestone) {
+                Milestone.findOne({
+                    pull: pull.number,
+                    repo: pull.base.repo.id
+                }, function(err, mile) {
                     if(!err) {
-                        pull.milestone = milestone;
+                        pull.milestone = mile;
                     }
                     return callback(null);
                 });

--- a/src/tests/server/webhooks/issues.js
+++ b/src/tests/server/webhooks/issues.js
@@ -60,8 +60,8 @@ describe('issue', function(done) {
 
         var milestoneStub = sinon.stub(Milestone, 'findOne', function(args, done) {
             assert.deepEqual(args, {
-                repo: 23588185,
-                number: 1
+                id: 847211,
+                repo: 23588185
             });
             done(null, null);
         });
@@ -95,10 +95,11 @@ describe('issue:opened', function(done) {
 
         var milestoneStub = sinon.stub(Milestone, 'findOne', function(args, done) {
             assert.deepEqual(args, {
-                repo: 23588185,
-                number: 3
+                id: 847368,
+                repo: 23588185
             });
             done(null, {
+                id: 847368,
                 pull: 1,
                 repo: 23588185,
                 number: 3
@@ -175,10 +176,11 @@ describe('issue:closed', function(done) {
 
         var milestoneStub = sinon.stub(Milestone, 'findOne', function(args, done) {
             assert.deepEqual(args, {
-                repo: 23588185,
-                number: 1
+                id: 847211,
+                repo: 23588185
             });
             done(null, {
+                id: 847211,
                 pull: 2,
                 repo: 23588185,
                 number: 1
@@ -272,10 +274,11 @@ describe('issue:closed', function(done) {
 
         var milestoneStub = sinon.stub(Milestone, 'findOne', function(args, done) {
             assert.deepEqual(args, {
-                repo: 23588185,
-                number: 1
+                id: 847211,
+                repo: 23588185
             });
             done(null, {
+                id: 847211,
                 pull: 2,
                 repo: 23588185,
                 number: 1


### PR DESCRIPTION
Implement migrations.

Fix bug where we were unable to create milestones. Because milestone numbers
are recycled we must save the id in our persistence, if ever our id does not match
github's id then we must remove our milestone document.