### PR TITLE
Add mixin for gray buttons: clear filter in pr list and open/closed in s...

### DIFF
--- a/src/client/assets/styles/_btn.scss
+++ b/src/client/assets/styles/_btn.scss
@@ -1,6 +1,16 @@
 .btn {
   
   &.btn-link {
+    @mixin graybutton($hovercolor) {
+      color: $gray;
+      padding: 0;
+
+      &:hover,
+      &.active {
+        color: $hovercolor;
+      }
+    }
+
     color: $brand-primary-muted;
 
     &:hover {
@@ -19,13 +29,11 @@
     }
 
     &.gray {
-      color: $gray;
-      padding: 0;
+      @include graybutton($gray-darker);
+    }
 
-      &:hover,
-      &.active {
-        color: $gray-darker;
-      }
+    &.inverse {
+      @include graybutton(#fff);
     }
   }
 


### PR DESCRIPTION
...idebar.

Commit bc0d8de7b20635511f64f27f49da8a7da58e6cf2 remove overwrote the colors of the sidebar buttons open/close PRs. The mixin added in the commit re-enables the correct colors of the sidebar and keeps the colors for the clear button.