### PR TITLE
Filter out duplicate issues

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "github-fork-ribbon-css": "~0.1.1",
     "bootstrap-sass-official": "~3.2.0",
-    "ngInfiniteScroll": "~1.1.2"
+    "ngInfiniteScroll": "~1.1.2",
+    "angular-filter": "~0.5.4"
   },
   "devDependencies": {
     "angular-mocks": "~1.2.19",

--- a/src/client/app.js
+++ b/src/client/app.js
@@ -8,7 +8,8 @@ var module = angular.module('app',
      'infinite-scroll',
      'ngSanitize',
      'angulartics',
-     'angulartics.google.analytics']);
+     'angulartics.google.analytics',
+        'angular.filter']);
 
 var filters = angular.module('ninja.filters', []);
 

--- a/src/client/home.html
+++ b/src/client/home.html
@@ -102,6 +102,7 @@
   <script src="//cdnjs.cloudflare.com/ajax/libs/angulartics/0.17.2/angulartics.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/angulartics/0.17.2/angulartics-ga.min.js"></script>
   <script src="/lib/ngInfiniteScroll/build/ng-infinite-scroll.min.js"></script>
+  <script src="/lib/angular-filter/dist/angular-filter.min.js"></script>
 
   <!-- APP -->
   <script src="/app.js"></script>

--- a/src/client/login.html
+++ b/src/client/login.html
@@ -79,6 +79,7 @@
   <script src="//cdnjs.cloudflare.com/ajax/libs/angulartics/0.17.2/angulartics.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/angulartics/0.17.2/angulartics-ga.min.js"></script>
   <script src="/lib/ngInfiniteScroll/build/ng-infinite-scroll.min.js"></script>
+  <script src="/lib/angular-filter/dist/angular-filter.min.js"></script>
 
   <!-- APP -->
   <script src="/app.js"></script>

--- a/src/client/templates/issue/list.html
+++ b/src/client/templates/issue/list.html
@@ -3,7 +3,7 @@
        infinite-scroll-disabled="state==='open' ? open.loading : closed.loading">
 
   <tr class="select" 
-      ng-repeat="issue in (state==='open' ? open : closed).value | filter:{state: state} | in:reference.issues:'number'"
+      ng-repeat="issue in (state==='open' ? open : closed).value | filter:{state: state} | in:reference.issues:'number' | unique: 'id' "
       ui-sref="repo.pull.issue.detail({ issue: issue.number })"
       ng-show="issue.milestone.id===pull.milestone.id">
 

--- a/src/tests/karma.ninja.js
+++ b/src/tests/karma.ninja.js
@@ -39,6 +39,7 @@ module.exports = function(config) {
             'http://cdnjs.cloudflare.com/ajax/libs/angulartics/0.17.2/angulartics-ga.min.js',
             'src/bower/ngInfiniteScroll/build/ng-infinite-scroll.min.js',
             'src/bower/angular-mocks/angular-mocks.js',
+            'src/bower/angular-filter/dist/angular-filter.min.js',
 
             // Client code
             'src/client/modules/config.js',


### PR DESCRIPTION
See #779 

When a 'issue:opened' web hook is received It's added to the issues list via ping on a socket. This is necessary to maintain the liveliness of the issues list. However, if you were to refresh the list before the web hook was received the issue would be duplicated. 

Speaking with @dfarr we decided to just filter out the duplicate issues, rather than introduce code. 

This was accomplished via the 'unique' filter which is part of [angular-filter](https://github.com/a8m/angular-filter)