### PR TITLE
Specify unicode-range

### DIFF
--- a/src/client/assets/fonts/ninjaicons.css
+++ b/src/client/assets/fonts/ninjaicons.css
@@ -9,7 +9,7 @@
     url("fonts/ninja.svg#ninja") format("svg");
   font-weight: normal;
   font-style: normal;
-
+  unicode-range: U+0061;
 }
 
 [data-icon]:before {

--- a/src/client/home.html
+++ b/src/client/home.html
@@ -16,7 +16,7 @@
 
   <!-- FONTS -->
   <link href="//fonts.googleapis.com/css?family=Open+Sans:300italic,300,400italic,400,600italic,600,700italic,700,800italic,800" rel="stylesheet" type="text/css">
-  <link href="/assets/fonts/ninjaicons.css" rel="stylesheet">
+  <link href="/assets/fonts/ninjaicons.css" rel="stylesheet" type="text/css">
 
   <!-- APP STYLESHEET -->
   <link href="/assets/styles/app.css" rel="stylesheet">


### PR DESCRIPTION
Only load the 'a' character to speed up loading of font,
will hopefully mitigate the bug where people are seeing
the 'a' instead of the ninja star.

https://developer.mozilla.org/en-US/docs/Web/CSS/unicode-range