### PR TITLE
fix gulp coverage

### DIFF
--- a/gulp/tasks/coverage.js
+++ b/gulp/tasks/coverage.js
@@ -15,7 +15,7 @@ gulp.task('coverage', function(cb) {
 });
 
 gulp.task('istanbul', function(cb) {
-  return gulp.src(config.istanbulSrc)
+  gulp.src(config.istanbulSrc)
     .pipe(istanbul())
     .pipe(istanbul.hookRequire())
     .on('finish', function() {


### PR DESCRIPTION
if i say `return` it calls the `cb` too much and coverage from istanbul never gets piped to coveralls. So I took it out.