### PR TITLE
add vendor autoprefixing to scss

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "mongodb-migrations": "^0.5.0",
     "mongoose": "^3.8.25",
     "node-sass": "^2.0.1",
-    "node-sass-middleware": "^0.5.0",
+    "node-sass-middleware": "git+https://github.com/reviewninja/node-sass-middleware.git",
     "nodemailer": "^1.3.2",
     "nodemailer-sendmail-transport": "^1.0.0",
     "nodemailer-smtp-transport": "^1.0.2",

--- a/src/client/assets/styles/_animations.scss
+++ b/src/client/assets/styles/_animations.scss
@@ -1,49 +1,3 @@
-@-webkit-keyframes wobble {
-  10% {
-    -webkit-transform: translateY(10px);
-  }
-
-  20% {
-    -webkit-transform: translateY(-10px);
-  }
-
-  30% {
-    -webkit-transform: translateY(8px);
-  }
-
-  40% {
-    -webkit-transform: translateY(-8px);
-  }
-
-  50% {
-    -webkit-transform: translateY(6px);
-  }
-
-  60% {
-    -webkit-transform: translateY(-6px);
-  }
-
-  70% {
-    -webkit-transform: translateY(4px);
-  }
-
-  80% {
-    -webkit-transform: translateY(-4px);
-  }
-
-  90% {
-    -webkit-transform: translateY(2px);
-  }
-
-  95% {
-    -webkit-transform: translateY(-2px);
-  }
-
-  100% {
-    -webkit-transform: translateY(0);
-  }
-}
-
 @keyframes wobble {
   10% {
     transform: translateY(10px);
@@ -91,12 +45,8 @@
 }
 
 .wobble-vertical {
-  -webkit-animation-duration: 0.75s;
   animation-duration: 0.75s;
-  -webkit-animation-iteration-count: 1;
   animation-iteration-count: 1;
-  -webkit-animation-name: wobble;
   animation-name: wobble;
-  -webkit-animation-timing-function: ease-out;
   animation-timing-function: ease-out;
 }

--- a/src/client/assets/styles/_code.scss
+++ b/src/client/assets/styles/_code.scss
@@ -12,10 +12,6 @@
     margin-left: -20px;
     position: absolute;
 
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    -webkit-user-select: none;    
     user-select: none;
 
     .octicon {
@@ -44,10 +40,6 @@
     border-right: 1px solid $code-line-number-color;
     text-align: right;
 
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    -webkit-user-select: none;    
     user-select: none;
 
     width: 30px;

--- a/src/client/assets/styles/_onboard.scss
+++ b/src/client/assets/styles/_onboard.scss
@@ -2,7 +2,6 @@
   list-style-type: none;
   padding: 0;
 
-  -webkit-transition: opacity 0.5s; 
   transition: opacity 0.5s;
 
   &.complete {
@@ -14,12 +13,10 @@
     display: inline;
     padding: 0 10px;
 
-    -webkit-transition: opacity 1s; 
     transition: opacity 1s;
 
     .octicon-check {
       opacity: 0;
-      -webkit-transition: opacity 1s; 
       transition: opacity 1s;
     }
 
@@ -47,7 +44,6 @@
 .onboard-complete {
   height: 0;
   opacity: 0;
-  -webkit-transition: opacity 0.5s 0.5s; 
   transition: opacity 0.5s 0.5s;
 
   &.complete {
@@ -62,16 +58,13 @@
 
 // transitions for elements on the page
 .ob {
-  -webkit-transition: -webkit-transform 1s;
   transition: transform 1s;
 }
 
 .scale {
-  -webkit-transform: scale(1.15, 1.15);
   transform: scale(1.15, 1.15);
 }
 
 .rotate {
-  -webkit-transform: rotate(360deg);
   transform: rotate(360deg);
 }

--- a/src/client/assets/styles/_panel.scss
+++ b/src/client/assets/styles/_panel.scss
@@ -7,20 +7,12 @@
     border-bottom: 0;
     color: #fff;
     
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    -webkit-user-select: none;    
     user-select: none;
   }
 
   .panel-body {
     border-bottom: 10px solid #fff;
 
-    -moz-transition: background-color 1000ms linear;
-    -ms-transition: background-color 1000ms linear;
-    -o-transition: background-color 1000ms linear;
-    -webkit-transition: background-color 1000ms linear;
     transition: background-color 1000ms linear;
 
     &.highlight {

--- a/src/client/assets/styles/_table.scss
+++ b/src/client/assets/styles/_table.scss
@@ -25,10 +25,6 @@ table {
 }
 
 .table-hover {
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  -webkit-user-select: none;    
   user-select: none;
 
   .select:hover {

--- a/src/client/assets/styles/_tabs.scss
+++ b/src/client/assets/styles/_tabs.scss
@@ -2,10 +2,6 @@
   > li > a {
     color: $brand-primary;
 
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    -webkit-user-select: none;    
     user-select: none;
   }
 

--- a/src/client/assets/styles/_trashcan.scss
+++ b/src/client/assets/styles/_trashcan.scss
@@ -3,10 +3,6 @@
   right: 20px;
   top: 16px; 
 
-  -moz-transition: right 0.2s ease-in;
-  -ms-transition: right 0.2s ease-in;
-  -o-transition: right 0.2s ease-in;
-  -webkit-transition: right 0.2s ease-in;
   transition: right 0.2s ease-in;
 
   &.confirm {
@@ -21,10 +17,6 @@
   right: 20px;
   top: 16px;
 
-  -moz-transition: opacity 0.1s 0.15s ease-in;
-  -ms-transition: opacity 0.1s 0.15s ease-in;
-  -o-transition: opacity 0.1s 0.15s ease-in;
-  -webkit-transition: opacity 0.1s 0.15s ease-in;
   transition: opacity 0.1s 0.15s ease-in;
 
   visibility: hidden;

--- a/src/client/assets/styles/_well.scss
+++ b/src/client/assets/styles/_well.scss
@@ -1,7 +1,5 @@
 .well,
 .well-sm {
-  -moz-box-shadow: none;
-  -webkit-box-shadow: none;
   box-shadow: none;
 
   margin-bottom: 10px;

--- a/src/client/assets/styles/app.scss
+++ b/src/client/assets/styles/app.scss
@@ -210,10 +210,6 @@ h2,
 h3,
 h4,
 .lead {
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -278,10 +274,6 @@ h4,
 .octicon-trashcan {
   cursor: pointer;
 
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -294,8 +286,6 @@ h4,
 }
 
 .octicon-rotate {
-  -ms-transform: rotate(90deg);
-  -webkit-transform: rotate(90deg);
   transform: rotate(90deg);
 }
 
@@ -317,10 +307,6 @@ textarea {
 }
 
 .no-select {
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  -webkit-user-select: none;
   user-select: none;
 }
 

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -116,7 +116,8 @@ async.series([
                 src: p,
                 dest: p,
                 outputStyle: 'compressed',
-                force: config.server.always_recompile_sass
+                force: config.server.always_recompile_sass,
+                autoprefix: true
             }));
             app.use(path, express.static(p));
         };


### PR DESCRIPTION
-made a [fork of node-sass-middleware](https://github.com/reviewninja/node-sass-middleware) that can take the option to use the autoprefixer-core module to render automatically vendor prefixed css
-required this fork in package.json and added the autoprefix option in app.js
-remove vendor prefixes