### PR TITLE
Travis will display failed build if deployment failed

### DIFF
--- a/.cf.sh
+++ b/.cf.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Download cf command line client
 wget -O - https://cli.run.pivotal.io/stable\?release\=linux64-binary\&source\=github | tar xvz -C .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ before_script:
 - gem install scss-lint
 after_script:
 - gulp coverage
-- if [[ $TRAVIS_PULL_REQUEST == 'false' && $TRAVIS_BRANCH == 'master' ]]; then ./.cf.sh review-ninja-staging; fi
-- if [[ $TRAVIS_PULL_REQUEST == 'false' && $TRAVIS_BRANCH == 'release' ]]; then ./.cf.sh review-ninja; fi
+- if [[ $TRAVIS_PULL_REQUEST == 'false' && $TRAVIS_BRANCH == 'master' ]]; then ./.cf.sh review-ninja-staging || exit $?; fi
+- if [[ $TRAVIS_PULL_REQUEST == 'false' && $TRAVIS_BRANCH == 'release' ]]; then ./.cf.sh review-ninja || exit $?; fi
 notifications:
   webhooks: http://api.codepipes.io/exec/5440169d92758e200017513a
   slack:


### PR DESCRIPTION
I've added
```
set -e
```
to ```.cf.sh``` in order to make the whole script fail if any of the deployment steps fail.

I've also added ```... || exit $?``` which will pass any deployment error code back to Travis.