### PR TITLE
Source .env file via npm library

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "mongodb-migrations": "^0.5.0",
     "mongodb-uri": "^0.9.7",
     "mongoose": "^4.0.2",
+    "node-env-file": "^0.1.7",
     "node-sass": "^3.1.1",
     "node-sass-middleware": "^0.6.0",
     "nodemailer": "^1.3.2",

--- a/src/config.js
+++ b/src/config.js
@@ -8,6 +8,12 @@
  */
 
 var mongoURI = require('mongodb-uri');
+var env = require('node-env-file');
+
+env('.env', {
+    logger: console,
+    raise: true
+});
 
 module.exports = {
 
@@ -147,5 +153,4 @@ module.exports = {
     client: {
         gacode: process.env.GACODE
     }
-
 };

--- a/src/config.js
+++ b/src/config.js
@@ -11,8 +11,7 @@ var mongoURI = require('mongodb-uri');
 var env = require('node-env-file');
 
 env('.env', {
-    logger: console,
-    raise: true
+    logger: console
 });
 
 module.exports = {

--- a/src/config.js
+++ b/src/config.js
@@ -8,11 +8,8 @@
  */
 
 var mongoURI = require('mongodb-uri');
-var env = require('node-env-file');
 
-env('.env', {
-    logger: console
-});
+require('node-env-file')('.env', {logger: console, raise: false});
 
 module.exports = {
 


### PR DESCRIPTION
Hola Palo Alto Ninjas,

because of another project I found a npm library called 'node-env-file'. It basically is capable of loading the environment varibles an ```.env``` file, so that the command ```source .env``` is not necessary anymore. 

Unforunately, I could not get reviewninja up and running on my local machine here, so I _could not test the stuff in this pull request_. But an ```npm install node-env-file --save``` should install the library and get this up and running. If I have more time in the next week, I'll try to fix my setup and test it myself... :smile: 

Bests from :de: ,
Fabian