### PR TITLE
Add shell script to enable blue/green deployment

### DIFF
--- a/.blue-green.sh
+++ b/.blue-green.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+# download cf cli
+wget -O - https://cli.run.pivotal.io/stable\?release\=linux64-binary\&source\=github | tar xvz -C .
+
+# login
+./cf login -a https://api.run.pivotal.io -u $CF_USER -p $CF_PASS
+
+if [ -z "$(./cf env review-ninja-staging-blue | grep \"staging.review.ninja\")" ]; then
+    A="review-ninja-staging-blue"
+    B="review-ninja-staging-green"
+else
+    A="review-ninja-staging-green"
+    B="review-ninja-staging-blue"
+fi
+
+# push app
+./cf push $A -c "node app.js" --no-manifest
+
+# map routes
+./cf map-route $A cfapps.io -n review-ninja-staging
+./cf map-route $A review.ninja -n staging
+
+# unmap routes
+./cf unmap-route $B cfapps.io -n review-ninja-staging
+./cf unmap-route $B review.ninja -n staging

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_script:
 - gem install scss-lint
 after_script:
 - gulp coverage
-- if [[ $TRAVIS_PULL_REQUEST == 'false' && $TRAVIS_BRANCH == 'master' ]]; then ./.cf.sh review-ninja-staging || exit $?; fi
+- if [[ $TRAVIS_PULL_REQUEST == 'false' && $TRAVIS_BRANCH == 'master' ]]; then ./.blue-green.sh || exit $?; fi
 - if [[ $TRAVIS_PULL_REQUEST == 'false' && $TRAVIS_BRANCH == 'release' ]]; then ./.cf.sh review-ninja || exit $?; fi
 notifications:
   webhooks: http://api.codepipes.io/exec/5440169d92758e200017513a

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,3 +1,4 @@
 applications:
 - name: review-ninja-staging
+  domain: review.ninja
   command: node app.js


### PR DESCRIPTION
Currently testing on master->staging, will change to enable
blue/green deployment on production only once stable.

To do before go-live:
- [ ] rename review-ninja to review-ninja-blue
- [ ] create review-ninja-green and set env variables
- [ ] rename review-ninja-staging-blue to review-ninja-staging
- [ ] delete review-ninja-staging-green
- [ ] disable blue/green deployment on staging
- [ ] enable blue/green deployment on production (`.travis.yml` and `.blue-green.sh`)

Addresses #910 