### PR TITLE
Redirect when no head or base sha specified

### DIFF
--- a/src/client/app.js
+++ b/src/client/app.js
@@ -91,7 +91,6 @@ module.config(['$stateProvider', '$urlRouterProvider', '$locationProvider', '$lo
             // Pull request state (abstract)
             //
             .state('repo.pull', {
-                abstract: true,
                 url: '/pull/:number',
                 templateUrl: '/templates/pull.html',
                 controller: 'PullCtrl',

--- a/src/client/controller/pull.js
+++ b/src/client/controller/pull.js
@@ -11,6 +11,14 @@
 module.controller('PullCtrl', ['$scope', '$rootScope', '$state', '$stateParams', '$modal', '$filter', '$HUB', '$RPC', 'Pull', 'Markdown', 'File', 'Comment', 'repo', 'pull', 'socket', '$timeout',
     function($scope, $rootScope, $state, $stateParams, $modal, $filter, $HUB, $RPC, Pull, Markdown, File, Comment, repo, pull, socket, $timeout) {
 
+        //
+        // HACK?
+        //
+
+        if($state.current.name === 'repo.pull') {
+            $state.go('.review.reviewList', {base: pull.value.base.sha, head: pull.value.head.sha});
+        }
+
         // set the states
         $scope.state = 'open';
 

--- a/src/tests/client/controller/PullCtrl.spec.js
+++ b/src/tests/client/controller/PullCtrl.spec.js
@@ -107,7 +107,8 @@ describe('Pull Controller', function() {
     }));
 
 
-    beforeEach(angular.mock.inject(function($injector, $rootScope, $controller, $stateParams, $q) {
+    beforeEach(angular.mock.inject(function($injector, $rootScope, $controller, $state, $stateParams, $q) {
+
         $stateParams.user = 'gabe';
         $stateParams.repo = 'test';
         $stateParams.number = 1;
@@ -118,17 +119,6 @@ describe('Pull Controller', function() {
         q = $q;
 
         SocketMock = new SocketMockFunc($rootScope);
-
-        var mockState = {
-            go: function(fakestate, fakeparams) {
-                var deferred = $q.defer();
-                deferred.resolve({
-                    value: true
-                });
-                var promise = deferred.promise;
-                return promise;
-            }
-        };
 
         var fakePull = {
             base: {
@@ -156,7 +146,6 @@ describe('Pull Controller', function() {
             var ctrl = $controller('PullCtrl', {
                 $scope: scope,
                 $rootScope: rootScope,
-                $state: mockState,
                 $modal: ModalMock,
                 Pull: PullMock,
                 Issue: IssueMock,


### PR DESCRIPTION
When you navigate to a PR directly (with no head/base sha) we
should redirect you to the appropriate state.