### PR TITLE
Push new comments directly to $scope object

### DIFF
--- a/src/client/controller/pull.js
+++ b/src/client/controller/pull.js
@@ -108,6 +108,10 @@ module.controller('PullCtrl', ['$scope', '$rootScope', '$state', '$stateParams',
                     commit_id: ref.sha,
                     path: ref.path,
                     position: ref.position
+                }, function(err, comment) {
+                    if(!err) {
+                        $scope.review.value.push(Comment.review(comment.value) && Markdown.render(comment.value));
+                    }
                 });
             }
         };
@@ -119,6 +123,10 @@ module.controller('PullCtrl', ['$scope', '$rootScope', '$state', '$stateParams',
                     repo: $stateParams.repo,
                     number: $stateParams.number,
                     body: comment
+                }, function(err, comment) {
+                    if(!err) {
+                        $scope.conversation.value.push(Markdown.render(comment.value));
+                    }
                 });
             }
         };

--- a/src/client/templates/reviewItem.html
+++ b/src/client/templates/reviewItem.html
@@ -13,7 +13,7 @@
 
 <div style="padding:20px 10px; margin-bottom:20px;">
   <table style="width:100%;">
-    <tr ng-repeat="comment in review.thread[$stateParams.ref].comments" ng-show="comment.html">
+    <tr ng-repeat="comment in review.thread[$stateParams.ref].comments | unique:'id'" ng-show="comment.html">
       <td style="width:42px; padding-right:10px; vertical-align:top;">
         <img ng-show="comment.user" ng-src="{{ comment.user ? comment.user.avatar_url + '&s=42' : '/assets/images/user_deleted.jpg'}}" width="42px" />
       </td>

--- a/src/client/templates/reviewList.html
+++ b/src/client/templates/reviewList.html
@@ -75,7 +75,7 @@
     <tab-heading><span class="octicon octicon-comment-discussion"></span> Conversation</tab-heading>
     <div style="padding:20px 10px; margin-bottom:20px;">
       <table style="width:100%;">
-        <tr ng-repeat="comment in conversation.value" ng-show="comment.html">
+        <tr ng-repeat="comment in conversation.value | unique:'id'" ng-show="comment.html">
           <td style="width:42px; padding-right:10px; vertical-align:top;">
             <img ng-show="comment.user" ng-src="{{ comment.user ? comment.user.avatar_url + '&s=42' : '/assets/images/user_deleted.jpg'}}" width="42px" />
           </td>


### PR DESCRIPTION
We now handle duplicates by filtering "unique" items on the
ng-repeat, this way we can handle immediate addition of
comments and websocket-recieved comments.

Fixed #940