### PR TITLE
Heroku  env variable for GITHUB_HOST

### DIFF
--- a/app.json
+++ b/app.json
@@ -28,6 +28,9 @@
     "GITHUB_SECRET": {
       "description": "Client Secret of your GitHub Application."
     },
+    "GITHUB_HOST":{
+      "description": "The hostname of your target GitHub instance. Defaults tp 'github.com'"
+    },
     "GITHUB_PROTOCOL": {
       "description": "The protocol of your target GitHub instance. Defaults to 'https'.",
       "required": false

--- a/app.json
+++ b/app.json
@@ -29,7 +29,8 @@
       "description": "Client Secret of your GitHub Application."
     },
     "GITHUB_HOST":{
-      "description": "The hostname of your target GitHub instance. Defaults tp 'github.com'"
+      "description": "The hostname of your target GitHub instance. Defaults tp 'github.com'.",
+      "required": false
     },
     "GITHUB_PROTOCOL": {
       "description": "The protocol of your target GitHub instance. Defaults to 'https'.",

--- a/app.json
+++ b/app.json
@@ -29,7 +29,7 @@
       "description": "Client Secret of your GitHub Application."
     },
     "GITHUB_HOST":{
-      "description": "The hostname of your target GitHub instance. Defaults tp 'github.com'.",
+      "description": "The hostname of your target GitHub instance. Defaults to 'github.com'.",
       "required": false
     },
     "GITHUB_PROTOCOL": {


### PR DESCRIPTION
While deploying this to Heroku and connecting it to my GHE instance, I noticed this needed a `GITHUB_HOST` variable to know where it was working from.

Let me know if this isn't correct. Happy to make fixes =)