### PR TITLE
Enable required status checks in the UI

### DIFF
--- a/src/client/controller/pull.js
+++ b/src/client/controller/pull.js
@@ -92,6 +92,14 @@ module.controller('PullCtrl', [
         // get the collaborators
         $scope.collaborators = Extra.collaborators($stateParams.user, $stateParams.repo);
 
+        // get the branch
+        $scope.branch = $HUB.call('repos', 'getBranch', {
+            user: $stateParams.user,
+            repo: $stateParams.repo,
+            branch: pull.value.base.ref,
+            headers: {'Accept': 'application/vnd.github.loki-preview+json'}
+        });
+
         $scope.comment = {};
         $scope.reviewComment = {};
 

--- a/src/client/directives/merge.js
+++ b/src/client/directives/merge.js
@@ -8,10 +8,11 @@ module.directive('mergeButton', ['$HUB', '$stateParams', '$timeout', '$filter', 
         restrict: 'E',
         templateUrl: '/directives/templates/merge.html',
         scope: {
-            permissions: '=',
             pull: '=',
-            reposettings: '=',
-            status: '='
+            status: '=',
+            protection: '=',
+            permissions: '=',
+            reposettings: '='
         },
         link: function(scope, elem, attrs) {
 
@@ -54,6 +55,19 @@ module.directive('mergeButton', ['$HUB', '$stateParams', '$timeout', '$filter', 
                     state: 'pending',
                     statuses: []
                 };
+            });
+
+            scope.$watch('status + permissions + protection', function() {
+                if(scope.status && scope.permissions && scope.protection) {
+                    scope.required = {};
+                    scope.required.pass = true;
+                    scope.required.over = scope.protection.required_status_checks.enforcement_level === 'non_admins' && scope.permissions.admin;
+                    scope.status.statuses.forEach(function(status) {
+                        if(status.state !== 'success' && scope.protection.required_status_checks.contexts.indexOf(status.context) > -1) {
+                            scope.required.pass = false;
+                        }
+                    });
+                }
             });
 
 

--- a/src/client/directives/merge.js
+++ b/src/client/directives/merge.js
@@ -23,14 +23,11 @@ module.directive('mergeButton', ['$HUB', '$stateParams', '$timeout', '$filter', 
             };
 
             if(scope.permissions.push && scope.pull.base.repo.id === scope.pull.head.repo.id) {
-                $HUB.call('gitdata', 'getReference', {
+                scope.branch = $HUB.call('repos', 'getBranch', {
                     user: $stateParams.user,
                     repo: $stateParams.repo,
-                    ref: 'heads/' + scope.pull.head.ref
-                }, function(err, ref) {
-                    if(!err) {
-                        scope.branch = true;
-                    }
+                    branch: scope.pull.head.ref,
+                    headers: {'Accept': 'application/vnd.github.loki-preview+json'}
                 });
             }
 
@@ -90,7 +87,7 @@ module.directive('mergeButton', ['$HUB', '$stateParams', '$timeout', '$filter', 
                     ref: 'heads/' + scope.pull.head.ref
                 }, function(err, result) {
                     if(!err) {
-                        scope.branch = false;
+                        scope.branch = null;
                         scope.branchRemoved = true;
                     }
                 });

--- a/src/client/directives/templates/merge.html
+++ b/src/client/directives/templates/merge.html
@@ -3,8 +3,7 @@
             'text-success': status.state==='success' && !pull.merged,
             'text-warning': status.state==='pending' && !pull.merged,
             'text-danger':  status.state==='failure' && !pull.merged,
-            'text-merged':  pull.merged,
-            'disabled': !pull.mergeable
+            'text-merged':  pull.merged
           }">
 
   <div ng-show="pull.merged && branch">
@@ -36,6 +35,9 @@
     <small ng-show="!pull.mergeable">
       Pull Request <a ng-href="{{ pull.html_url }}" class="link-external" target="_blank">#{{ pull.number }}</a> can't be merged automatically.
     </small>
+    <small ng-show="required && !required.pass && !required.over">
+      All required services on this pull request must run successfully to enable automatic merging.
+    </small>
   </div>
 
   <button type="button"
@@ -48,7 +50,7 @@
             'wobble-vertical': $root.ob === 'ob-merge'
           }"
           ng-show="permissions.push || pull.merged"
-          ng-disabled="!pull.mergeable"
+          ng-disabled="!pull.mergeable || (required && !required.pass && !required.over)"
           ng-click="merge()">
 
     <span ng-show="!pull.merged">

--- a/src/client/directives/templates/merge.html
+++ b/src/client/directives/templates/merge.html
@@ -6,7 +6,7 @@
             'text-merged':  pull.merged
           }">
 
-  <div ng-show="pull.merged && branch">
+  <div ng-show="pull.merged && branch.value && !branch.value.protection.enabled">
     <span class="trashcan text-danger octicon octicon-trashcan no-select"
           ng-class="{confirm: showConfirmation}"
           ng-click="confirm()"
@@ -49,18 +49,16 @@
             'btn-merged':  pull.merged,
             'wobble-vertical': $root.ob === 'ob-merge'
           }"
-          ng-show="permissions.push || pull.merged"
+          ng-show="permissions.push && !pull.merged"
           ng-disabled="!pull.mergeable || (required && !required.pass && !required.over)"
           ng-click="merge()">
-
-    <span ng-show="!pull.merged">
-      <span class="octicon octicon-git-merge"></span> {{ status.state==='failure' ? 'Merge with caution!' : 'Merge pull request'}}
-    </span>
-    <span ng-show="pull.merged">
-      <span class="octicon octicon-git-pull-request"></span> Merged
-    </span>
+    <span class="octicon octicon-git-merge"></span> {{ status.state==='failure' ? 'Merge with caution!' : 'Merge pull request'}}
     <i class="fa fa-spinner fa-spin" ng-show="merging.loading"></i>
   </button>
+
+  <span ng-show="pull.merged" style="font-size: 16px; font-weight: normal;">
+    <span class="octicon octicon-git-pull-request"></span> Merged
+  </span>
 
   <div class="text-body" ng-show="pull.merged">
     <p>{{ status.count | pluralize:'service' }} <strong>{{ status.text }}</strong></p>

--- a/src/client/templates/pull.html
+++ b/src/client/templates/pull.html
@@ -24,6 +24,7 @@
                         status="status.value"
                         permissions="repo.permissions"
                         reposettings="reposettings"
+                        protection="branch.value.protection"
                         get-long-star-text="getLongStarText()"
                         ng-show="status.loaded">
           </merge-button>
@@ -154,7 +155,10 @@
                 <th>Status</th>
               </tr>
               <tr ng-repeat="status in status.value.statuses">
-                <td>{{ status.context }}</td>
+                <td>
+                  {{ status.context }}
+                  <span ng-show="branch.value.protection.required_status_checks.enforcement_level !== 'off' && branch.value.protection.required_status_checks.contexts.indexOf(status.context) > -1" class="label label-default">Required</span>
+                </td>
                 <td><a class="link-external" ng-href="{{ status.target_url }}" target="_blank">{{ status.description }}</a></td>
                 <td ng-class="{'text-success': status.state==='success', 'text-warning': status.state==='pending', 'text-danger': status.state==='failure'}">
                   <span class="octicon" ng-class="{'octicon-check': status.state==='success', 'octicon-x': status.state!=='success'}"></span>

--- a/src/tests/client/controller/PullCtrl.spec.js
+++ b/src/tests/client/controller/PullCtrl.spec.js
@@ -120,6 +120,19 @@ describe('Pull Controller', function() {
         })).respond({
             value: 'success'
         });
+
+        httpBackend.expect('POST', '/api/github/call', JSON.stringify({
+          obj: 'repos',
+          fun: 'getBranch',
+          arg: {
+            user: 'gabe',
+            repo: 'test',
+            branch: 'master',
+            headers: {'Accept': 'application/vnd.github.loki-preview+json'}
+          }
+        })).respond({
+            value: 'success'
+        });
     }));
 
 
@@ -144,7 +157,8 @@ describe('Pull Controller', function() {
                     },
                     name: 'repo1',
                     id: 11111
-                }
+                },
+                ref: 'master'
             },
             head: {
                 sha: 'abcd1234'

--- a/src/tests/client/directives/merge.spec.js
+++ b/src/tests/client/directives/merge.spec.js
@@ -46,10 +46,11 @@ describe('Merge Directive', function() {
     }));
 
     it('should get ref if base and head are equal', function() {
-        httpBackend.expect('POST', '/api/github/call', '{"obj":"gitdata","fun":"getReference","arg":' + JSON.stringify({
+        httpBackend.expect('POST', '/api/github/call', '{"obj":"repos","fun":"getBranch","arg":' + JSON.stringify({
            user: 'gabe',
            repo: 'test',
-           ref: 'heads/master'
+           branch: 'master',
+           headers: {'Accept': 'application/vnd.github.loki-preview+json'}
         }) + '}').respond({
             value: true
         });
@@ -83,7 +84,7 @@ describe('Merge Directive', function() {
         elScope.deleteBranch();
         (elScope.showConfirmation).should.be.false;
         httpBackend.flush();
-        (elScope.branch).should.be.false;
+        ([elScope.branch]).should.be.eql([null]);
         (elScope.branchRemoved).should.be.true;
     });
 


### PR DESCRIPTION
Now that GitHub supports required status checks (and so does their API) we should surface this information, and disable the merge button accordingly.