### PR TITLE
Add link to review and add orgs to authorization

### DIFF
--- a/src/client/controller/home.js
+++ b/src/client/controller/home.js
@@ -33,6 +33,8 @@ module.controller('HomeCtrl', ['$rootScope', '$scope', '$state', '$stateParams',
             });
         });
 
+        $scope.auth = $RPC.call('user', 'authorization');
+
         //
         // Actions
         //

--- a/src/client/templates/home.html
+++ b/src/client/templates/home.html
@@ -50,9 +50,13 @@
           <i class="fa fa-lg fa-spinner fa-spin pull-right" ng-show="active===repo" style="padding-top:3px;"></i>
         </a>
       </div>
-      <div ng-show="allRepos.hasMore">
+      <div ng-show="allRepos.hasMore" style="padding-bottom: 10px;">
         <strong class="text-primary" style="padding:0 10px;">Not finding your repo?</strong> 
         <button class="btn btn-xs btn-primary" ng-click="allRepos.getMore()">Load more</button>
+      </div>
+      <div ng-show="auth.value">
+        <strong class="text-primary" style="padding:0 10px;">Is an organization missing?</strong> 
+        <a ng-href="{{ auth.value.html_url }}" target="_blank" class="btn btn-xs btn-primary" role="button">Review and add</a>
       </div>
     </div>
 

--- a/src/tests/client/controller/HomeCtrl.spec.js
+++ b/src/tests/client/controller/HomeCtrl.spec.js
@@ -22,6 +22,8 @@ describe('Home Controller', function() {
             }
         });
 
+        httpBackend.expect('POST', '/api/user/authorization').respond({value: true});
+
         scope = $rootScope.$new();
         rootScope = $rootScope;
 


### PR DESCRIPTION
With githubs new org permissions apps must be explicitly
added to third party permissions. This will link to the proper
place in GH to do so for RN.

Resolves #886