### PR TITLE
Enable monkey patching strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ test
 coverage
 src/client/assets/styles/app.css
 src/client/assets/styles/app.css.map
+src/server/monkey/*.js
 .sass-cache
 npm-shrinkwrap.json
 .idea/

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "passport-slack": "git+https://github.com/dfarr/passport-slack.git",
     "request": "^2.53.0",
     "socket.io": "^1.3.5",
+    "tunnel": "0.0.4",
     "underscore": "^1.8.3",
     "winston-papertrail": "^1.0.1",
     "x-frame-options": "^1.0.0"

--- a/src/config.js
+++ b/src/config.js
@@ -136,6 +136,10 @@ module.exports = {
 
         passport: [
             __dirname + '/server/passports/*.js'
+        ],
+
+        monkey: [
+            __dirname + '/server/monkey/*.js'
         ]
     },
 

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -86,7 +86,7 @@ async.series([
 
         if(config.server.https.certs) {
             glob(config.server.https.certs, function(err, file) {
-                if (file && file.length) {
+                if(file && file.length) {
                     file.forEach(function(f) {
                         try {
                             https.globalAgent.options.ca = https.globalAgent.options.ca || [];
@@ -147,7 +147,7 @@ async.series([
 
         async.eachSeries(config.server.migrations, function(p, callback) {
             glob(p, function(err, file) {
-                if (file && file.length) {
+                if(file && file.length) {
                     file.forEach(function(f) {
                         try {
                             migrator.add(require(f));
@@ -186,7 +186,7 @@ async.series([
 
         async.eachSeries(config.server.documents, function(p, callback) {
             glob(p, function(err, file) {
-                if (file && file.length) {
+                if(file && file.length) {
                     file.forEach(function(f) {
                         try {
                             global.models = merge(global.models, require(f));
@@ -212,7 +212,7 @@ async.series([
 
         async.eachSeries(config.server.passport, function(p, callback) {
             glob(p, function(err, file) {
-                if (file && file.length) {
+                if(file && file.length) {
                     file.forEach(function(f) {
                         console.log('✓ '.bold.green + path.relative(process.cwd(), f));
                         require(f);
@@ -233,7 +233,7 @@ async.series([
 
         async.eachSeries(config.server.controller, function(p, callback) {
             glob(p, function(err, file) {
-                if (file && file.length) {
+                if(file && file.length) {
                     file.forEach(function(f) {
                         try {
                             app.use('/', require(f));
@@ -259,7 +259,7 @@ async.series([
 
         async.eachSeries(config.server.api, function(p, callback) {
             glob(p, function(err, file) {
-                if (file && file.length) {
+                if(file && file.length) {
                     file.forEach(function(f) {
                         console.log('✓ '.bold.green + path.relative(process.cwd(), f));
                         api[path.basename(f, '.js')] = require(f);
@@ -280,7 +280,7 @@ async.series([
 
         async.eachSeries(config.server.webhooks, function(p, callback) {
             glob(p, function(err, file) {
-                if (file && file.length) {
+                if(file && file.length) {
                     file.forEach(function(f) {
                         console.log('✓ '.bold.green + path.relative(process.cwd(), f));
                         webhooks[path.basename(f, '.js')] = require(f);
@@ -289,6 +289,28 @@ async.series([
                 callback();
             });
         }, callback);
+    },
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
+    // Bootstrap monkey patch
+    //////////////////////////////////////////////////////////////////////////////////////////////
+
+    function(callback) {
+
+        console.log('bootstrap monkey patch'.bold);
+
+        async.eachSeries(config.server.monkey, function(m, callback) {
+            glob(m, function(err, file) {
+                if(file && file.length) {
+                    file.forEach(function(f) {
+                        console.log('✓ '.bold.green + path.relative(process.cwd(), f));
+                        require(f);
+                    });
+                }
+                callback();
+            });
+        }, callback);
+
     }
 
 ], function(err, res) {

--- a/src/server/monkey/README.md
+++ b/src/server/monkey/README.md
@@ -1,0 +1,32 @@
+# Monkey Patching
+
+Any `.js` files included here are automatically bootstrapped on application startup. This is useful for monkey patching dependencies in order to modify code at runtime.
+
+For example, we are using the following to implement proxy support.
+
+```js
+var https = require('https');
+var tunnel = require('tunnel');
+
+var tunnelingAgent = tunnel.httpsOverHttp({
+    proxy: {
+        host: 'mycompany.com',
+        port: 8080
+    }
+});
+
+module.exports = function() {
+
+    var _request = https.request;
+
+    https.request = function(options, callback) {
+
+        if(!/^.*.mycompany.com$/.test(options.host)) {
+            options.agent = tunnelingAgent;
+        }
+
+        return _request.call(null, options, callback);
+    };
+
+}();
+```


### PR DESCRIPTION
On bootstrap, we will require all js files in the 'server/monkey'
folder. This is a useful place for custom installtions to modify
code in runtime via monkey patching. For example, enabling proxy
support for the http/https node libraries.