### PR TITLE
NPM: Updates GitHub from 2.4 to 2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "express": "^4.12.3",
     "express-session": "^1.10.4",
     "extend": "^3.0.0",
-    "github": "^2.4.0",
+    "github": "^2.6.0",
     "glob": "^7.0.5",
     "less-middleware": "^2.0.1",
     "merge": "^1.2.0",


### PR DESCRIPTION
Outdated npm dependency, GitHub 2.4 updated to 2.6.

Needs testing. 
